### PR TITLE
Allowing passing --user to adb when starting app

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -564,6 +564,8 @@ class AndroidDevice extends Device {
         ...<String>['--ez', 'trace-startup', 'true'],
       if (route != null)
         ...<String>['--es', 'route', route],
+      if (debuggingOptions.androidUser.isNotEmpty) 
+        ...<String>['--user', debuggingOptions.androidUser],
       if (debuggingOptions.enableSoftwareRendering)
         ...<String>['--ez', 'enable-software-rendering', 'true'],
       if (debuggingOptions.skiaDeterministicRendering)

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -157,6 +157,11 @@ class RunCommand extends RunCommandBase {
         hide: !verboseHelp,
         help: 'Specify the project root directory.',
       )
+      ..addOption(
+        'android-user',
+        hide: !verboseHelp,
+        help: 'If needed specify the android user.',
+      )
       ..addFlag('machine',
         hide: !verboseHelp,
         negatable: false,
@@ -359,6 +364,7 @@ class RunCommand extends RunCommandBase {
       return DebuggingOptions.enabled(
         buildInfo,
         startPaused: boolArg('start-paused'),
+        androidUser: stringArg('android-user'),
         disableServiceAuthCodes: boolArg('disable-service-auth-codes'),
         dartFlags: stringArg('dart-flags') ?? '',
         useTestFonts: boolArg('use-test-fonts'),

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -565,6 +565,7 @@ class DebuggingOptions {
     this.startPaused = false,
     this.disableServiceAuthCodes = false,
     this.dartFlags = '',
+    this.androidUser = '',
     this.enableSoftwareRendering = false,
     this.skiaDeterministicRendering = false,
     this.traceSkia = false,
@@ -600,6 +601,7 @@ class DebuggingOptions {
       useTestFonts = false,
       startPaused = false,
       dartFlags = '',
+      androidUser = '',
       disableServiceAuthCodes = false,
       enableSoftwareRendering = false,
       skiaDeterministicRendering = false,
@@ -618,6 +620,7 @@ class DebuggingOptions {
   final BuildInfo buildInfo;
   final bool startPaused;
   final String dartFlags;
+  final String androidUser;
   final bool disableServiceAuthCodes;
   final bool enableSoftwareRendering;
   final bool skiaDeterministicRendering;


### PR DESCRIPTION
## Description

In this PR I am adding a possibility to set --user to adb when starting and Android app, this is a parameter from **flutter run** command called **android-user**.

So if you want to start the app using another user in Android device you should run something like this
```bash
flutter run --android-user 10
```

## Related Issues

Fixes #20324

## Tests

No tests were added, if I need to add some, let me know
